### PR TITLE
Sync readme example payload with drone-plugin-go types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@ This plugin is responsible for sending build notifications to your Slack channel
         "self_url": "http://my.drone.io/foo/bar"
     },
     "build" : {
-        "status": "success",
         "number": 22,
+        "status": "success",
         "started_at": 1421029603,
         "finished_at": 1421029813,
-        "message": "Update the Readme",
-        "commit": {
+        "head_commit": {
             "sha": "9f2849d5",
             "branch": "master",
+            "message": "Update the Readme",
             "author": {
                 "login": "johnsmith",
-                "author": "john.smith@gmail.com"
+                "email": "john.smith@gmail.com"
             }
         }
     },
     "vargs": {
         "webhook_url": "https://hooks.slack.com/services/...",
-        "username": "drone", 
+        "username": "drone",
         "channel": "#dev"
     }
 }
@@ -56,21 +56,26 @@ docker run -i plugins/drone-slack <<EOF
     "repo" : {
         "owner": "foo",
         "name": "bar",
-        "self": "http://my.drone.io/foo/bar"
+        "self_url": "http://my.drone.io/foo/bar"
     },
-    "commit" : {
-        "state": "success",
+    "build" : {
+        "number": 22,
+        "status": "success",
         "started_at": 1421029603,
         "finished_at": 1421029813,
-        "sha": "9f2849d5",
-        "branch": "master",
-        "pull_request": "800",
-        "author": "john.smith@gmail.com",
-        "message": "Update the Readme"
+        "head_commit": {
+            "sha": "9f2849d5",
+            "branch": "master",
+            "message": "Update the Readme",
+            "author": {
+                "login": "johnsmith",
+                "email": "john.smith@gmail.com"
+            }
+        }
     },
     "vargs": {
         "webhook_url": "https://hooks.slack.com/services/...",
-        "username": "drone", 
+        "username": "drone",
         "channel": "#dev"
     }
 }


### PR DESCRIPTION
The example payload is simply damn outdated and doesn't work like that anymore.
Fixes #2.