### PR TITLE
fix: SLACK_WEBHOOK -> PLUGIN_WEBHOOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Post the build status to a channel:
 
 ```
 docker run --rm \
-    -e SLACK_WEBHOOK=https://hooks.slack.com/services/... \
+    -e PLUGIN_WEBHOOK=https://hooks.slack.com/services/... \
     -e PLUGIN_CHANNEL=foo \
     -e PLUGIN_USERNAME=drone \
     -e DRONE_REPO_OWNER=octocat \

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "webhook",
 			Usage:  "slack webhook url",
-			EnvVar: "SLACK_WEBHOOK",
+			EnvVar: "PLUGIN_WEBHOOK",
 		},
 		cli.StringFlag{
 			Name:   "channel",


### PR DESCRIPTION
I couldn't get any slack notifications without setting the webhook like this for 0.5.

With this change, I can now get at least a message to slack... Although it's reporting the status as pending, no other statuses come out (even when the build completes). Need to look at that more.