### PR TITLE
Support define success or failure message format.

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,11 +47,6 @@ func main() {
 			EnvVar: "PLUGIN_TEMPLATE",
 		},
 		cli.StringFlag{
-			Name:   "image",
-			Usage:  "slack image url",
-			EnvVar: "PLUGIN_IMAGE_URL",
-		},
-		cli.StringFlag{
 			Name:   "repo.owner",
 			Usage:  "repository owner",
 			EnvVar: "DRONE_REPO_OWNER",
@@ -124,7 +119,6 @@ func run(c *cli.Context) error {
 			Recipient: c.String("recipient"),
 			Username:  c.String("username"),
 			Template:  c.String("template"),
-			ImageURL:  c.String("image_url"),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,46 @@ func main() {
 			EnvVar: "PLUGIN_TEMPLATE",
 		},
 		cli.StringFlag{
+			Name:   "success.username",
+			Usage:  "username for successful builds",
+			EnvVar: "PLUGIN_SUCCESS_USERNAME",
+		},
+		cli.StringFlag{
+			Name:   "success.icon",
+			Usage:  "icon for successful builds",
+			EnvVar: "PLUGIN_SUCCESS_ICON",
+		},
+		cli.StringFlag{
+			Name:   "success.template",
+			Usage:  "template for successful builds",
+			EnvVar: "PLUGIN_SUCCESS_TEMPLATE",
+		},
+		cli.StringSliceFlag{
+			Name:   "success.image_attachments",
+			Usage:  "image attachments for successful builds",
+			EnvVar: "PLUGIN_SUCCESS_IMAGE_ATTACHMENTS",
+		},
+		cli.StringFlag{
+			Name:   "failure.username",
+			Usage:  "username for failed builds",
+			EnvVar: "PLUGIN_FAILURE_USERNAME",
+		},
+		cli.StringFlag{
+			Name:   "failure.icon",
+			Usage:  "icon for failed builds",
+			EnvVar: "PLUGIN_FAILURE_ICON",
+		},
+		cli.StringFlag{
+			Name:   "failure.template",
+			Usage:  "template for failed builds",
+			EnvVar: "PLUGIN_FAILURE_TEMPLATE",
+		},
+		cli.StringSliceFlag{
+			Name:   "failure.image_attachments",
+			Usage:  "image attachments for failed builds",
+			EnvVar: "PLUGIN_FAILURE_IMAGE_ATTACHMENTS",
+		},
+		cli.StringFlag{
 			Name:   "repo.owner",
 			Usage:  "repository owner",
 			EnvVar: "DRONE_REPO_OWNER",
@@ -119,6 +159,18 @@ func run(c *cli.Context) error {
 			Recipient: c.String("recipient"),
 			Username:  c.String("username"),
 			Template:  c.String("template"),
+			Success: MessageOptions{
+				Username:         c.String("success.username"),
+				Icon:             c.String("success.icon"),
+				Template:         c.String("success.template"),
+				ImageAttachments: c.StringSlice("success.image_attachments"),
+			},
+			Failure: MessageOptions{
+				Username:         c.String("failure.username"),
+				Icon:             c.String("failure.icon"),
+				Template:         c.String("failure.template"),
+				ImageAttachments: c.StringSlice("failure.image_attachments"),
+			},
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -29,7 +29,6 @@ type (
 		Recipient string
 		Username  string
 		Template  string
-		ImageURL  string
 	}
 
 	Plugin struct {
@@ -45,7 +44,6 @@ func (p Plugin) Exec() error {
 		Fallback:   fallback(p.Repo, p.Build),
 		Color:      color(p.Build),
 		MarkdownIn: []string{"text", "fallback"},
-		ImageURL:   p.Config.ImageURL,
 	}
 
 	payload := slack.WebHookPostPayload{}


### PR DESCRIPTION
@tboerger 

* Remove `image_url` flag.
* Support define success or failure message format.

Error:

<img width="263" alt="screen shot 2016-08-17 at 10 42 25 pm" src="https://cloud.githubusercontent.com/assets/21979/17740644/fa4f0ea8-64cb-11e6-922c-af01eef7928c.png">

Success:

<img width="472" alt="screen shot 2016-08-17 at 10 42 43 pm" src="https://cloud.githubusercontent.com/assets/21979/17740657/00d12450-64cc-11e6-9092-d3e2440d0934.png">

example:

```
docker run --rm \
  -e SLACK_WEBHOOK=https://hooks.slack.com/xxxxxx \
  -e PLUGIN_CHANNEL=drone \
  -e PLUGIN_USERNAME=drone \
  -e PLUGIN_SUCCESS_USERNAME=success \
  -e PLUGIN_SUCCESS_ICON=https://cdn0.iconfinder.com/data/icons/round-ui-icons/128/tick_green.png \
  -e PLUGIN_FAILURE_USERNAME=failure \
  -e PLUGIN_FAILURE_ICON=:+1: \
  -e PLUGIN_FAILURE_IMAGE_ATTACHMENTS=https://cdn0.iconfinder.com/data/icons/shift-free/32/Error-128.png \
  -e PLUGIN_FAILURE_TEMPLATE="build status {{ build.status }}" \
  -e DRONE_BUILD_STATUS=failure \
  -e DRONE_REPO_OWNER=octocat \
  -e DRONE_REPO_NAME=hello-world \
  -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \
  -e DRONE_COMMIT_BRANCH=master \
  -e DRONE_COMMIT_AUTHOR=octocat \
  -e DRONE_BUILD_NUMBER=1 \
  -e DRONE_BUILD_LINK=http://github.com/octocat/hello-world \
  plugins/slack
```

Fixed #10, Closed #21 