### PR TITLE
Support image, icon_url, icon_emoji

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -10,7 +10,7 @@ The following parameters are used to configure the plugin:
 * **recipient** - alternatively you can send it to a specific user
 * **username** - choose the username this integration will post as
 * **template** - overwrite the default message template
-* **image** - A valid URL to an image file that will be displayed inside a message attachment
+* **image_url** - A valid URL to an image file that will be displayed inside a message attachment
 * **icon_url** - A valid URL that displays a image to the left of the username
 * **icon_emoji** - displays a emoji to the left of the username
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -10,6 +10,9 @@ The following parameters are used to configure the plugin:
 * **recipient** - alternatively you can send it to a specific user
 * **username** - choose the username this integration will post as
 * **template** - overwrite the default message template
+* **image** - A valid URL to an image file that will be displayed inside a message attachment
+* **icon_url** - A valid URL that displays a image to the left of the username
+* **icon_emoji** - displays a emoji to the left of the username
 
 The following secret values can be set to configure the plugin.
 
@@ -54,4 +57,43 @@ pipeline:
     username: drone
     template: >
       build #{{ build.number }} finished with a {{ build.status }} status
+```
+
+Example attach image inside a message:
+
+```yaml
+pipeline:
+  slack:
+    webhook: https://hooks.slack.com/services/...
+    channel: dev
+    username: drone
+    template: >
+      build #{{ build.number }} finished with a {{ build.status }} status
+    image: https://cdn3.iconfinder.com/data/icons/picons-social/57/16-apple-128.png
+```
+
+Example change user avatar via icon URL:
+
+```yaml
+pipeline:
+  slack:
+    webhook: https://hooks.slack.com/services/...
+    channel: dev
+    username: drone
+    template: >
+      build #{{ build.number }} finished with a {{ build.status }} status
+    icon_url: https://cdn0.iconfinder.com/data/icons/shift-free/32/Error-128.png
+```
+
+Example change user avatar via icon emoji:
+
+```yaml
+pipeline:
+  slack:
+    webhook: https://hooks.slack.com/services/...
+    channel: dev
+    username: drone
+    template: >
+      build #{{ build.number }} finished with a {{ build.status }} status
+    icon_emoji: :+1:
 ```

--- a/main.go
+++ b/main.go
@@ -52,12 +52,12 @@ func main() {
 			EnvVar: "PLUGIN_IMAGE_URL",
 		},
 		cli.StringFlag{
-			Name:   "icon_url",
+			Name:   "icon.url",
 			Usage:  "slack icon url",
 			EnvVar: "PLUGIN_ICON_URL",
 		},
 		cli.StringFlag{
-			Name:   "icon_emoji",
+			Name:   "icon.emoji",
 			Usage:  "slack emoji url",
 			EnvVar: "PLUGIN_ICON_EMOJI",
 		},
@@ -135,8 +135,8 @@ func run(c *cli.Context) error {
 			Username:  c.String("username"),
 			Template:  c.String("template"),
 			ImageURL:  c.String("image"),
-			IconURL:   c.String("icon_url"),
-			IconEmoji: c.String("icon_emoji"),
+			IconURL:   c.String("icon.url"),
+			IconEmoji: c.String("icon.emoji"),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,6 +52,16 @@ func main() {
 			EnvVar: "PLUGIN_IMAGE_URL",
 		},
 		cli.StringFlag{
+			Name:   "icon_url",
+			Usage:  "slack icon url",
+			EnvVar: "PLUGIN_ICON_URL",
+		},
+		cli.StringFlag{
+			Name:   "icon_emoji",
+			Usage:  "slack emoji url",
+			EnvVar: "PLUGIN_ICON_EMOJI",
+		},
+		cli.StringFlag{
 			Name:   "repo.owner",
 			Usage:  "repository owner",
 			EnvVar: "DRONE_REPO_OWNER",
@@ -124,7 +134,9 @@ func run(c *cli.Context) error {
 			Recipient: c.String("recipient"),
 			Username:  c.String("username"),
 			Template:  c.String("template"),
-			ImageURL:  c.String("image_url"),
+			ImageURL:  c.String("image"),
+			IconURL:   c.String("icon_url"),
+			IconEmoji: c.String("icon_emoji"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -30,6 +30,8 @@ type (
 		Username  string
 		Template  string
 		ImageURL  string
+		IconURL   string
+		IconEmoji string
 	}
 
 	Plugin struct {
@@ -51,6 +53,8 @@ func (p Plugin) Exec() error {
 	payload := slack.WebHookPostPayload{}
 	payload.Username = p.Config.Username
 	payload.Attachments = []*slack.Attachment{&attachment}
+	payload.IconUrl = p.Config.IconURL
+	payload.IconEmoji = p.Config.IconEmoji
 
 	if p.Config.Recipient == "" {
 		payload.Channel = prepend("#", p.Config.Channel)


### PR DESCRIPTION
Since #22 has been closed. I create new PR to add `image`, `icon_url` and `icon_emoji` flag to fix #10 

`icon_emoji`:
![screen shot 2016-08-18 at 9 17 36 am](https://cloud.githubusercontent.com/assets/21979/17758764/af43ddf4-6524-11e6-8b35-5749f6fc956c.png)

`icon_url`:
![screen shot 2016-08-18 at 9 17 44 am](https://cloud.githubusercontent.com/assets/21979/17758765/af4d5258-6524-11e6-8c7a-f73415a92c11.png)

docker example:

```
docker run --rm \
  -e SLACK_WEBHOOK=https://hooks.slack.com/services/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 \
  -e PLUGIN_CHANNEL=drone \
  -e PLUGIN_USERNAME=drone \
  -e PLUGIN_IMAGE_URL=https://cdn0.iconfinder.com/data/icons/shift-free/32/Error-128.png \
  -e PLUGIN_ICON_URL=https://cdn3.iconfinder.com/data/icons/picons-social/57/16-apple-128.png \
  -e PLUGIN_ICON_EMOJI=:+1: \
  -e DRONE_BUILD_STATUS=failure \
  -e DRONE_REPO_OWNER=octocat \
  -e DRONE_REPO_NAME=hello-world \
  -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \
  -e DRONE_COMMIT_BRANCH=master \
  -e DRONE_COMMIT_AUTHOR=octocat \
  -e DRONE_BUILD_NUMBER=1 \
  -e DRONE_BUILD_LINK=http://github.com/octocat/hello-world \
  plugins/slack
```

cc @tboerger @bradrydzewski 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>