### PR TITLE
adding ref to build

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,12 @@ func main() {
 			EnvVar: "DRONE_COMMIT_SHA",
 		},
 		cli.StringFlag{
+			Name:   "commit.ref",
+			Value:  "refs/heads/master",
+			Usage:  "git commit ref",
+			EnvVar: "DRONE_COMMIT_REF",
+		},
+		cli.StringFlag{
 			Name:   "commit.branch",
 			Value:  "master",
 			Usage:  "git commit branch",
@@ -138,6 +144,7 @@ func run(c *cli.Context) error {
 			Event:  c.String("build.event"),
 			Status: c.String("build.status"),
 			Commit: c.String("commit.sha"),
+			Ref:    c.String("commit.ref"),
 			Branch: c.String("commit.branch"),
 			Author: c.String("commit.author"),
 			Link:   c.String("build.link"),

--- a/plugin.go
+++ b/plugin.go
@@ -18,6 +18,7 @@ type (
 		Event  string
 		Number int
 		Commit string
+		Ref    string
 		Branch string
 		Author string
 		Status string


### PR DESCRIPTION
# Context

This PR adds `DRONE_COMMIT_REF` value to the `Build.Ref` field, so it's exposed and can be used in a custom `template:`