### PR TITLE
Update docs about using '>' over '|' for templates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -58,7 +58,7 @@ pipeline:
     image: plugins/slack
     webhook: https://hooks.slack.com/services/...
     channel: dev
-+   template: |
++   template: >
 +     {{ #success build.status }}
 +       build {{ build.number }} succeeded. Good job.
 +     {{ else }}


### PR DESCRIPTION
Using the `|` notation from readme didn't work for me.

I'm using drone version 0.5 and got this message instead:
```
Parse error on line 1:
Lexer error
Token: Error{"Unexpected character in expression: '#'"}
```

but when I changed my slack template to use `>` it started working.