### PR TITLE
Add `dry-run` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,11 @@ func main() {
 	app.Action = run
 	app.Version = fmt.Sprintf("1.1.0+%s", build)
 	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:   "dry-run",
+			Usage:  "dry run disables posting message to slack",
+			EnvVar: "SLACK_DRY_RUN,PLUGIN_DRY_RUN",
+		},
 		cli.StringFlag{
 			Name:   "webhook",
 			Usage:  "slack webhook url",
@@ -198,6 +203,7 @@ func run(c *cli.Context) error {
 			IconURL:   c.String("icon.url"),
 			IconEmoji: c.String("icon.emoji"),
 		},
+		DryRun: c.Bool("dry-run"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -50,6 +50,7 @@ type (
 		Build  Build
 		Config Config
 		Job    Job
+		DryRun bool
 	}
 )
 
@@ -83,7 +84,13 @@ func (p Plugin) Exec() error {
 	}
 
 	client := slack.NewWebHook(p.Config.Webhook)
-	return client.PostMessage(&payload)
+	if p.DryRun {
+		fmt.Println("dry-run enabled, skipping post to slack")
+
+		return nil
+	} else {
+		return client.PostMessage(&payload)
+	}
 }
 
 func message(repo Repo, build Build) string {


### PR DESCRIPTION
I would like to skip posting to slack based on run-time conditions. I didn't see a way to do that without adding a `dry-run` flag.
