### PR TITLE
Adds S3 username translation support

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -47,11 +47,17 @@ type (
 		Started int64
 	}
 
+	Computed struct {
+		AuthorSlack    string
+		RecipientSlack string
+	}
+
 	Plugin struct {
-		Repo   Repo
-		Build  Build
-		Config Config
-		Job    Job
+		Repo     Repo
+		Build    Build
+		Config   Config
+		Job      Job
+		Computed Computed
 	}
 )
 
@@ -70,8 +76,8 @@ func (p Plugin) Exec() error {
 	payload.IconUrl = p.Config.IconURL
 	payload.IconEmoji = p.Config.IconEmoji
 
-	if p.Config.Recipient != "" {
-		payload.Channel = prepend("@", p.Config.Recipient)
+	if p.Computed.RecipientSlack != "" {
+		payload.Channel = prepend("@", p.Computed.RecipientSlack)
 	} else if p.Config.Channel != "" {
 		payload.Channel = prepend("#", p.Config.Channel)
 	}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+func loadUserMapFromS3(bucket, key string) (map[string]string, error) {
+	if bucket == "" || key == "" {
+		return nil, nil
+	}
+
+	config := &aws.Config{
+		Region: aws.String("us-west-2"),
+	}
+
+	sess := session.Must(session.NewSession(config))
+	downloader := s3manager.NewDownloader(sess)
+
+	requestInput := s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	}
+
+	buf := aws.NewWriteAtBuffer([]byte{})
+	if _, err := downloader.Download(buf, &requestInput); err != nil {
+		return nil, err
+	}
+
+	users := map[string]string{}
+	if err := json.Unmarshal(buf.Bytes(), &users); err != nil {
+		return nil, err
+	}
+
+	return users, nil
+}
+
+func translateOrReturn(key string, dict map[string]string) string {
+	// nil dict will always return exists = false
+	if value, exists := dict[key]; exists {
+		return value
+	}
+
+	return key
+}


### PR DESCRIPTION
**Note** My team's use of drone and slack required for there to be some way to translate between github usernames and slack usernames.  I'm throwing this PR out there incase others can benefit. I realize this is a bit special case to be merged into master, but if there are suggestions on how to generalize this in such a way that it could, I'm willing to work on this further.

This adds the ability to translate usernames following a json map in
a specified S3 bucket/file.

The new environment variables/options:
PLUGIN_S3_BUCKET and PLUGIN_S3_USERS_KEY can be set to an S3 bucket
and file key respectively. This will cause the plugin to load that
file and use its json string -> string object map to translate the
`build.author` and `recipient` fields into `computed.authorSlack` and
`computed.recipientSlack`.

These new fields can be used in templates normally. The
recipient option (to send a slack message to a specific user
vs a channel) with automatically translate the name when the
new S3 options are set.

The format of the JSON file:
{
   "gitUserName": "slackUserName",
}

