### PR TITLE
feat: use vars_file to inject variables into template

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -41,6 +41,7 @@ type (
 		IconURL   string
 		IconEmoji string
 		LinkNames bool
+		Vars      map[string]string
 	}
 
 	Job struct {


### PR DESCRIPTION
After using plugins/docker to tag docker image by .tags file, I want to send the tag name to slack channel. For this purpose, I try to implement `vars_file` to pass variables inside template. 

It looks like below example

```
pipeline:
  setup_docker_version:
    image: alpine:latest
    commands:
      - VERSION=$(date '+%Y%m%d%H%M%S')
      - echo "VERSION=$$VERSION" > env
      - echo "$$VERSION" > .tags

  docker:
    image: plugins/docker
    repo: someone/a-image
    secrets: [ docker_username, docker_password ]

  slack:
    image: plugins/slack
    webhook: url
    channel: some
    username: some
    vars_file: env
    template: >
      *{{repo.name}}*: build <{{build.link}}|{{build.number}}> succeeded.
        - docker version: {{config.vars.version}}
```

I also found the issue #82 , but I'm not sure that the feature whether can resolve it or not. 