### PR TITLE
render template without trim

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -125,7 +125,8 @@ func (p Plugin) Exec() error {
 }
 
 func templateMessage(t string, plugin Plugin) (string, error) {
-	return template.Render(t, plugin)
+	t = strings.Replace(t, "\\n", "\n", -1)
+	return template.RenderTrim(t, plugin)
 }
 
 func message(repo Repo, build Build) string {

--- a/plugin.go
+++ b/plugin.go
@@ -125,7 +125,7 @@ func (p Plugin) Exec() error {
 }
 
 func templateMessage(t string, plugin Plugin) (string, error) {
-	return template.RenderTrim(t, plugin)
+	return template.Render(t, plugin)
 }
 
 func message(repo Repo, build Build) string {


### PR DESCRIPTION
Potential solution for https://github.com/drone-plugins/drone-slack/issues/30? It would help create cleaner slack templates without redundant line breaks.