### PR TITLE
support environment variables related branch informations

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,11 @@ func main() {
 			EnvVar: "DRONE_REPO_NAME",
 		},
 		cli.StringFlag{
+			Name:   "repo.branch",
+			Usage:  "default repository branch name",
+			EnvVar: "DRONE_REPO_BRANCH",
+		},
+		cli.StringFlag{
 			Name:   "commit.sha",
 			Usage:  "git commit sha",
 			EnvVar: "DRONE_COMMIT_SHA",
@@ -173,6 +178,16 @@ func main() {
 			EnvVar: "DRONE_TAG",
 		},
 		cli.StringFlag{
+			Name:   "source.branch",
+			Usage:  "source branch for the pull request",
+			EnvVar: "DRONE_SOURCE_BRANCH",
+		},
+		cli.StringFlag{
+			Name:   "target.branch",
+			Usage:  "target branch for the pull request",
+			EnvVar: "DRONE_TARGET_BRANCH",
+		},
+		cli.StringFlag{
 			Name:   "build.deployTo",
 			Usage:  "environment deployed to",
 			EnvVar: "DRONE_DEPLOY_TO",
@@ -196,8 +211,9 @@ func main() {
 func run(c *cli.Context) error {
 	plugin := Plugin{
 		Repo: Repo{
-			Owner: c.String("repo.owner"),
-			Name:  c.String("repo.name"),
+			Owner:  c.String("repo.owner"),
+			Name:   c.String("repo.name"),
+			Branch: c.String("repo.branch"),
 		},
 		Build: Build{
 			Tag:    c.String("build.tag"),
@@ -219,6 +235,12 @@ func run(c *cli.Context) error {
 			Link:     c.String("build.link"),
 			Started:  c.Int64("build.started"),
 			Created:  c.Int64("build.created"),
+		},
+		Source: Source{
+			Branch: c.String("source.branch"),
+		},
+		Target: Target{
+			Branch: c.String("target.branch"),
 		},
 		Job: Job{
 			Started: c.Int64("job.started"),

--- a/plugin.go
+++ b/plugin.go
@@ -10,8 +10,9 @@ import (
 
 type (
 	Repo struct {
-		Owner string
-		Name  string
+		Owner  string
+		Name   string
+		Branch string
 	}
 
 	Build struct {
@@ -29,6 +30,14 @@ type (
 		Link     string
 		Started  int64
 		Created  int64
+	}
+
+	Source struct {
+		Branch string
+	}
+
+	Target struct {
+		Branch string
 	}
 
 	Author struct {
@@ -65,6 +74,8 @@ type (
 	Plugin struct {
 		Repo   Repo
 		Build  Build
+		Source Source
+		Target Target
 		Config Config
 		Job    Job
 	}


### PR DESCRIPTION
Hello, I want to use variables that related branch for push or pull request. Drone support its by environment variables, so I add flags to drone-slack.

* [DRONE_REPO_BRANCH](https://docs.drone.io/pipeline/environment/reference/drone-repo-branch/)
* [DRONE_SOURCE_BRANCH](https://docs.drone.io/pipeline/environment/reference/drone-source-branch/)
* [DRONE_TARGET_BRANCH](https://docs.drone.io/pipeline/environment/reference/drone-target-branch/)