### PR TITLE
added a debug mode and includes failed steps variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,58 @@ docker run --rm \
   -e DRONE_TAG=1.0.0 \
   plugins/slack
 ```
+
+### Template
+Add the `PLUGIN_TEMPLATE` variable and set it to a valid Go template:
+
+```
+docker run --rm \
+  -e SLACK_WEBHOOK=https://hooks.slack.com/services/... \
+  -e PLUGIN_CHANNEL=foo \
+  -e PLUGIN_USERNAME=drone \
+  -e DRONE_REPO_OWNER=octocat \
+  -e DRONE_REPO_NAME=hello-world \
+  -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \
+  -e DRONE_COMMIT_BRANCH=master \
+  -e DRONE_COMMIT_AUTHOR=octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e DRONE_COMMIT_AUTHOR_AVATAR="https://avatars0.githubusercontent.com/u/583231?s=460&v=4" \
+  -e DRONE_COMMIT_AUTHOR_NAME="The Octocat" \
+  -e DRONE_BUILD_NUMBER=1 \
+  -e DRONE_BUILD_STATUS=success \
+  -e DRONE_BUILD_LINK=http://github.com/octocat/hello-world \
+  -e DRONE_TAG=1.0.0 \
+  -e PLUGIN_TEMPLATE='{{#success build.status}} Deployed to staging in {{since build.created}} from Drone.
+        {{else}} Failed to deployed at step "{{build.failedSteps}}" after {{since build.created}}.
+        {{/success}}' \
+  -e DEBUG=true \
+  plugins/slack
+```
+
+### Debug
+Add the `DEBUG=true variable`:
+
+```
+docker run --rm \
+  -e SLACK_WEBHOOK=https://hooks.slack.com/services/... \
+  -e PLUGIN_CHANNEL=foo \
+  -e PLUGIN_USERNAME=drone \
+  -e DRONE_REPO_OWNER=octocat \
+  -e DRONE_REPO_NAME=hello-world \
+  -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \
+  -e DRONE_COMMIT_BRANCH=master \
+  -e DRONE_COMMIT_AUTHOR=octocat \
+  -e DRONE_COMMIT_AUTHOR_EMAIL=octocat@github.com \
+  -e DRONE_COMMIT_AUTHOR_AVATAR="https://avatars0.githubusercontent.com/u/583231?s=460&v=4" \
+  -e DRONE_COMMIT_AUTHOR_NAME="The Octocat" \
+  -e DRONE_BUILD_NUMBER=1 \
+  -e DRONE_BUILD_STATUS=failed \
+  -e DRONE_BUILD_LINK=http://github.com/octocat/hello-world \
+  -e DRONE_TAG=1.0.0 \
+  -e DRONE_FAILED_STEPS=clone \
+  -e PLUGIN_TEMPLATE='{{#success build.status}} Deployed to staging in {{since build.created}} from Drone.
+        {{else}} Failed to deployed at step "{{build.failedSteps}}" after {{since build.created}}.
+        {{/success}}' \
+  -e DEBUG=true \
+  plugins/slack
+```

--- a/main.go
+++ b/main.go
@@ -182,6 +182,22 @@ func main() {
 			Usage:  "job started",
 			EnvVar: "DRONE_JOB_STARTED",
 		},
+
+		cli.StringFlag{
+			Name:   "build.failedStages",
+			Usage:  "comma separated list of failed stages",
+			EnvVar: "DRONE_FAILED_STAGES",
+		},
+		cli.StringFlag{
+			Name:   "build.failedSteps",
+			Usage:  "comma separated list of failed steps",
+			EnvVar: "DRONE_FAILED_STEPS",
+		},
+		cli.BoolFlag{
+			Name:   "debug",
+			Usage:  "enable debug logs",
+			EnvVar: "DEBUG",
+		},
 	}
 
 	if _, err := os.Stat("/run/drone/env"); err == nil {
@@ -200,13 +216,15 @@ func run(c *cli.Context) error {
 			Name:  c.String("repo.name"),
 		},
 		Build: Build{
-			Tag:    c.String("build.tag"),
-			Number: c.Int("build.number"),
-			Event:  c.String("build.event"),
-			Status: c.String("build.status"),
-			Commit: c.String("commit.sha"),
-			Ref:    c.String("commit.ref"),
-			Branch: c.String("commit.branch"),
+			Tag:          c.String("build.tag"),
+			Number:       c.Int("build.number"),
+			Event:        c.String("build.event"),
+			Status:       c.String("build.status"),
+			FailedSteps:  c.String("build.failedSteps"),
+			FailedStages: c.String("build.failedStages"),
+			Commit:       c.String("commit.sha"),
+			Ref:          c.String("commit.ref"),
+			Branch:       c.String("commit.branch"),
 			Author: Author{
 				Username: c.String("commit.author"),
 				Name:     c.String("commit.author.name"),
@@ -235,6 +253,7 @@ func run(c *cli.Context) error {
 			IconEmoji: c.String("icon.emoji"),
 			Color:     c.String("color"),
 			LinkNames: c.Bool("link-names"),
+			Debug:     c.Bool("debug"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -15,20 +15,22 @@ type (
 	}
 
 	Build struct {
-		Tag      string
-		Event    string
-		Number   int
-		Commit   string
-		Ref      string
-		Branch   string
-		Author   Author
-		Pull     string
-		Message  Message
-		DeployTo string
-		Status   string
-		Link     string
-		Started  int64
-		Created  int64
+		Tag          string
+		Event        string
+		Number       int
+		Commit       string
+		Ref          string
+		Branch       string
+		Author       Author
+		Pull         string
+		Message      Message
+		DeployTo     string
+		Status       string
+		FailedSteps  string
+		FailedStages string
+		Link         string
+		Started      int64
+		Created      int64
 	}
 
 	Author struct {
@@ -56,6 +58,7 @@ type (
 		IconEmoji string
 		Color     string
 		LinkNames bool
+		Debug     bool
 	}
 
 	Job struct {
@@ -133,6 +136,9 @@ func (p Plugin) Exec() error {
 		attachment.Text = message(p.Repo, p.Build)
 	}
 
+	if p.Config.Debug {
+		fmt.Printf("Sending msg: %s", attachment.Text)
+	}
 	client := slack.NewWebHook(p.Config.Webhook)
 	return client.PostMessage(&payload)
 }


### PR DESCRIPTION
Drone set the two variables, [DRONE_FAILED_STEPS](https://docs.drone.io/pipeline/environment/reference/drone-failed-steps/) and [DRONE_FAILED_STAGES](https://docs.drone.io/pipeline/environment/reference/drone-failed-stages/) when some steps fail. 
This PR add them as usable variables for the templating system, so custom messages to slack can give more insight.

It also add support for the `DEBUG` env variable that will dump the Slack message to the console. It's meant to be used for testing purpose only.