### PR TITLE
Remove author name from attachment

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -96,7 +96,6 @@ func (p Plugin) Exec() error {
 	attachment := slack.Attachment{
 		Color:      p.Config.Color,
 		ImageURL:   p.Config.ImageURL,
-		AuthorName: "drone-slack",
 		MarkdownIn: []string{"text", "fallback"},
 	}
 	if p.Config.Color == "" {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -20,7 +20,7 @@ func TestExec(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		out, _ := io.ReadAll(r.Body)
 		got := string(out)
-		want := `{"attachments":[{"color":"good","fallback":"Message Template Fallback:\nInitial commit\nmaster\nsuccess","author_name":"drone-slack","text":"Message Template:\nInitial commit\n\nMessage body\nInitial commit\nMessage body","mrkdwn_in":["text","fallback"],"blocks":null}],"replace_original":false,"delete_original":false}`
+		want := `{"attachments":[{"color":"good","fallback":"Message Template Fallback:\nInitial commit\nmaster\nsuccess","text":"Message Template:\nInitial commit\n\nMessage body\nInitial commit\nMessage body","mrkdwn_in":["text","fallback"],"blocks":null}],"replace_original":false,"delete_original":false}`
 		assert.Equal(t, got, want)
 	}
 


### PR DESCRIPTION
The value appears in the UI and can distract from the message text.

